### PR TITLE
Generated images compatibility with anything other than npm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -346,7 +346,6 @@ module.exports = function imageLoader (moduleOptions: IModuleOptions) {
   const validResponsiveStyles = moduleOptions.responsiveStyles && typeof moduleOptions.responsiveStyles === 'object' ? Object.keys(moduleOptions.responsiveStyles) : []
   const responsiveStyles = moduleOptions.responsiveStyles && typeof moduleOptions.responsiveStyles === 'object' ? moduleOptions.responsiveStyles : {}
 
-  const buildType = process.env.npm_lifecycle_event
 
   this.addServerMiddleware({ path: '', handler: imageLoaderHandler })
   this.addPlugin({
@@ -358,7 +357,7 @@ module.exports = function imageLoader (moduleOptions: IModuleOptions) {
     }
   })
 
-  if (buildType === 'generate') {
+  if (this.options.target === 'static') {
     const generateDir = this.nuxt.options.generate.dir
     process.$imageLoaderRegistry = []
     this.nuxt.hook('generate:done', async function(nuxt, errors) {


### PR DESCRIPTION
Instead of checking if the current process runs within a npm script named generate, I suggest looking at nuxt's target.
This caused my images not to be generated as my npm script was called differently and on my build system I was not using npm at all.